### PR TITLE
fix: remove query param from manifest entry of img

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@aem-screens/screens-offlineresources-generator",
-    "version": "1.0.1-SCRNS-3513.0",
+    "version": "1.0.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@aem-screens/screens-offlineresources-generator",
-    "version": "1.0.0",
+    "version": "1.0.1-SCRNS-3513.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@aem-screens/screens-offlineresources-generator",
-    "version": "1.0.1-SCRNS-3513.0",
+    "version": "1.0.1",
     "description": "Screens module to generate offline resources for Screens channels created through Franklin",
     "main": "src/index.js",
     "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@aem-screens/screens-offlineresources-generator",
-    "version": "1.0.0",
+    "version": "1.0.1-SCRNS-3513.0",
     "description": "Screens module to generate offline resources for Screens channels created through Franklin",
     "main": "src/index.js",
     "type": "module",

--- a/src/createManifest.js
+++ b/src/createManifest.js
@@ -23,13 +23,12 @@ export default class ManifestGenerator {
    *
    */
   static trimImagesPath = (item, index, arr) => {
-    const item1 = item.trim();
-    arr[index] = item1[0] === '.' ? item1.substring(1, item1.length) : item1;
+    const trimmedItem = item.trim();
+    const isRelative = trimmedItem[0] === '.';
+    const noDot = isRelative ? trimmedItem.substring(1) : trimmedItem;
     // remove query param from image path if present
-    const queryIndex = arr[index].indexOf('?');
-    if (queryIndex > 0) {
-      arr[index] = arr[index].substring(0, queryIndex);
-    }
+    const noQuery = noDot.split('?')[0];
+    arr[index] = noQuery;
   };
 
   /**

--- a/src/createManifest.js
+++ b/src/createManifest.js
@@ -25,6 +25,11 @@ export default class ManifestGenerator {
   static trimImagesPath = (item, index, arr) => {
     const item1 = item.trim();
     arr[index] = item1[0] === '.' ? item1.substring(1, item1.length) : item1;
+    // remove query param from image path if present
+    const queryIndex = arr[index].indexOf('?');
+    if (queryIndex > 0) {
+      arr[index] = arr[index].substring(0, queryIndex);
+    }
   };
 
   /**
@@ -94,15 +99,15 @@ export default class ManifestGenerator {
       resourceEntry.path = resourcesArr[i];
       // timestamp is optional value, only add if last-modified available
       const date = resp.headers.get('last-modified');
-      if (date) {
+      if (ManifestGenerator.isMedia(resourceSubPath)) {
+        resourceEntry.path = parentPath.concat(resourceEntry.path);
+        resourceEntry.hash = ManifestGenerator.getHashFromMedia(resourceSubPath);
+      } else if (date) {
         const timestamp = new Date(date).getTime();
         if (timestamp > lastModified) {
           lastModified = timestamp;
         }
         resourceEntry.timestamp = timestamp;
-      } else if (ManifestGenerator.isMedia(resourceSubPath)) {
-        resourceEntry.path = parentPath.concat(resourceEntry.path);
-        resourceEntry.hash = ManifestGenerator.getHashFromMedia(resourceSubPath);
       }
       entriesJson.push(resourceEntry);
     }


### PR DESCRIPTION
Manifest entry for Images contain query param, eg: `/content/screens/conference-rooms/Gather/media_1b41e396687e973df6f4e84d3e545c2dc888ce1e0.jpeg?width=750&format=webply&optimize=medium`

As a result, players download low resolution images.

This changes removes the query param in path for Images.