### PR TITLE
fix: dont fetch channels's .html if its html is updated

### DIFF
--- a/src/createManifest.js
+++ b/src/createManifest.js
@@ -50,14 +50,16 @@ export default class ManifestGenerator {
    */
   static getPageJsonEntry = async (host, path, isHtmlUpdated) => {
     const entryPath = `${path}.html`;
-    const resp = await FetchUtils.fetchDataWithMethod(host, entryPath, 'HEAD');
     const entry = { path: entryPath };
-    // timestamp is optional value, only add if last-modified available
-    const date = resp && resp.headers.get('last-modified');
     if (isHtmlUpdated) {
       entry.timestamp = new Date().getTime();
-    } else if (date) {
-      entry.timestamp = new Date(date).getTime();
+    } else {
+      const resp = await FetchUtils.fetchDataWithMethod(host, entryPath, 'HEAD');
+      const date = resp && resp.headers.get('last-modified');
+      // timestamp is optional value, only add if last-modified available
+      if (date) {
+        entry.timestamp = new Date(date).getTime();
+      }
     }
     return entry;
   };


### PR DESCRIPTION
## **Bug**
When new channels are created, to generate their manifest current logic expects the `<channel-path>.html` to be present in franklin to get the last-modified which was not used since the last-modified in that case should be current time.
But in case of newly created channels it gives `404` error since the html is not pushed to git yet.

## **Fix**
While creating manifest of a channel, if the `isHtmlUpdated` attribute is true, then don't fetch the `.html` from git unnecessarily.


<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
