### PR TITLE
fix: use sourceLastModified for resources in code bus

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@aem-screens/screens-offlineresources-generator",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@aem-screens/screens-offlineresources-generator",
-            "version": "1.0.3",
+            "version": "1.0.4",
             "license": "Apache-2.0",
             "dependencies": {
                 "@adobe/helix-shared-git": "3.0.0",
@@ -5208,8 +5208,7 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-2.2.0.tgz",
             "integrity": "sha512-+OJ9konv95ClSTOJCmMZqpd5+YGsB2S+x6w3E1oaM8UuR5j8nTNHYSz8c9BEPGDOCMQYIEEGlVPj/VY64iTbGw==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "@eslint/eslintrc": {
             "version": "1.4.1",
@@ -5424,8 +5423,7 @@
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
             "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "aggregate-error": {
             "version": "3.1.0",
@@ -7623,8 +7621,7 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz",
             "integrity": "sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "postcss-selector-parser": {
             "version": "6.0.11",
@@ -8173,15 +8170,13 @@
             "version": "9.0.4",
             "resolved": "https://registry.npmjs.org/stylelint-config-prettier/-/stylelint-config-prettier-9.0.4.tgz",
             "integrity": "sha512-38nIGTGpFOiK5LjJ8Ma1yUgpKENxoKSOhbDNSemY7Ep0VsJoXIW9Iq/2hSt699oB9tReynfWicTAoIHiq8Rvbg==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "stylelint-config-recommended": {
             "version": "9.0.0",
             "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-9.0.0.tgz",
             "integrity": "sha512-9YQSrJq4NvvRuTbzDsWX3rrFOzOlYBmZP+o513BJN/yfEmGSr0AxdvrWs0P/ilSpVV/wisamAHu5XSk8Rcf4CQ==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "stylelint-config-standard": {
             "version": "29.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@aem-screens/screens-offlineresources-generator",
-    "version": "1.0.4",
+    "version": "1.0.5-pre-1",
     "description": "Screens module to generate offline resources for Screens channels created through Franklin",
     "main": "src/index.js",
     "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@aem-screens/screens-offlineresources-generator",
-    "version": "1.0.5-pre-1",
+    "version": "1.0.5",
     "description": "Screens module to generate offline resources for Screens channels created through Franklin",
     "main": "src/index.js",
     "type": "module",

--- a/src/createManifest.js
+++ b/src/createManifest.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-await-in-loop */
 /*
  * Copyright 2023 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
@@ -11,57 +10,58 @@
  * governing permissions and limitations under the License.
  */
 
-import Constants from './constants.js';
 import FetchUtils from './utils/fetchUtils.js';
 import PathUtils from './utils/pathUtils.js';
 import GitUtils from './utils/gitUtils.js';
 
+/**
+ * Trims the image path and removes any query parameters from it.
+ * Modifies the original array in place.
+ *
+ * @param {string} item - The image path to be trimmed and modified.
+ * @param {number} index - The index of the current item in the array.
+ * @param {Array.<string>} arr - The array containing the image paths.
+ * @returns {void}
+ */
+const trimImagesPath = (item, index, arr) => {
+  const trimmedItem = item.trim();
+  const isRelative = trimmedItem[0] === '.';
+  const noDot = isRelative ? trimmedItem.substring(1) : trimmedItem;
+  // remove query param from image path if present
+  const noQuery = noDot.split('?')[0];
+  // Update the item in the original array
+  arr[index] = noQuery;
+};
+
 export default class ManifestGenerator {
-  /**
-   * If the image path starts with a '.' then trim it to exclude it
-   *
-   */
-  static trimImagesPath = (item, index, arr) => {
-    const trimmedItem = item.trim();
-    const isRelative = trimmedItem[0] === '.';
-    const noDot = isRelative ? trimmedItem.substring(1) : trimmedItem;
-    // remove query param from image path if present
-    const noQuery = noDot.split('?')[0];
-    arr[index] = noQuery;
-  };
+  constructor(host, indexedManifestsMap) {
+    this.host = host;
+    this.indexedManifestsMap = indexedManifestsMap;
+  }
 
   /**
-   * Checks if the image is hosted in franklin
-   */
-  static isMedia = (path) => path.trim().includes(Constants.MEDIA_PREFIX);
-
-  /**
-   * For images hosted in Franklin, hash values are appended in name.
-   */
-  static getHashFromMedia = (path) => {
-    const path1 = path.trim();
-    return path1.substring(Constants.MEDIA_PREFIX.length, path1.indexOf('.'));
-  };
-
-  static extractMediaFromPath = (path) => path.trim().substring(path.indexOf(Constants.MEDIA_PREFIX));
-
-  /**
-   * @param {string} host - custom host for the franklin site
    * @param {string} path - resource path
    * @returns {Promise<string>} - last modified for resource
    * @throws {Error} - when resource does not exist
+   *
+   * media resources are not supported by admin APIs
    */
-  static getLastModified = async (host, path) => {
-    // media resources are not supported by admin APIs
-    const gitUrl = await GitUtils.getOriginURL(process.cwd(), {});
-    const branch = await GitUtils.getBranch(process.cwd());
+  getLastModified = async (path) => {
+    // if file is modified in current run, use current timestamp
+    if (await GitUtils.isFileDirty(path.slice(1))) {
+      return new Date().getTime();
+    }
+
+    this.gitUrl = this.gitUrl || await GitUtils.getOriginURL(process.cwd(), {});
+    this.branch = this.branch || await GitUtils.getBranch(process.cwd());
     const resp = await FetchUtils.fetchDataWithMethod(
-      `https://admin.hlx.page/status/${gitUrl.owner}/${gitUrl.repo}/${branch}`,
+      `https://admin.hlx.page/status/${this.gitUrl.owner}/${this.gitUrl.repo}/${this.branch}`,
       path,
       'GET'
     );
     const jsonResponse = await resp.json();
     if (jsonResponse.code?.status === 200) {
+      // use sourceLastModified for code
       return new Date(jsonResponse.code.sourceLastModified).getTime();
     }
     if (jsonResponse.live?.status === 200) {
@@ -74,118 +74,114 @@ export default class ManifestGenerator {
   /**
    * Creating Page entry for manifest
    */
-  static getPageJsonEntry = async (host, path, isHtmlUpdated) => {
-    const entryPath = `${path}.html`;
-    const entry = { path: entryPath };
-    if (isHtmlUpdated) {
-      entry.timestamp = new Date().getTime();
-    } else {
-      entry.timestamp = await this.getLastModified(host, entryPath);
-    }
-    return entry;
+  getPageJsonEntry = async (channelPath) => {
+    const path = `${channelPath}.html`;
+    return {
+      path,
+      timestamp: await this.getLastModified(path)
+    };
   };
 
   /**
-   * Create the manifest entries
+   * Creates manifest entries for a given channel.
+   *
+   * @param {string} channelPath - The path of the channel.
+   * @param {Set<string>} pageResources - Set of page resources.
+   * @param {boolean} isHtmlUpdated - Indicates whether HTML is updated.
+   * @returns {Promise<[Object[], number]>} - A promise resolving to
+   *  an array containing the manifest entries JSON and the last modified timestamp.
    */
-  static createEntries = async (host, path, pageResources, isHtmlUpdated) => {
+  createManifestEntriesForChannel = async (channelPath, pageResources) => {
     let resourcesArr = [];
     if (pageResources && pageResources.size > 0) {
       resourcesArr = Array.from(pageResources);
     }
     const entriesJson = [];
-    let lastModified = 0;
-    const parentPath = PathUtils.getParentFromPath(path);
-    const pageEntryJson = await ManifestGenerator.getPageJsonEntry(host, path, isHtmlUpdated);
-    if (pageEntryJson.timestamp && pageEntryJson.timestamp > lastModified) {
-      lastModified = pageEntryJson.timestamp;
-    }
+    const parentPath = PathUtils.getParentFromPath(channelPath);
+    const pageEntryJson = await this.getPageJsonEntry(channelPath);
+    let lastModified = pageEntryJson.timestamp;
     entriesJson.push(pageEntryJson);
-    for (let i = 0; i < resourcesArr.length; i++) {
-      const resourceSubPath = resourcesArr[i].trim();
-      const resourceEntry = {};
-      resourceEntry.path = resourcesArr[i];
 
-      // media resources have hash, does not need timestamp to track changes
-      if (this.isMedia(resourceSubPath)) {
+    await Promise.all(resourcesArr.map(async (resourcePath) => {
+      const resourceEntry = {};
+      resourceEntry.path = resourcePath.trim();
+
+      // Media resources have hash and do not need a timestamp to track changes
+      if (PathUtils.isMedia(resourceEntry.path)) {
+        resourceEntry.hash = PathUtils.getHashFromMedia(resourceEntry.path);
         resourceEntry.path = parentPath.concat(resourceEntry.path);
-        resourceEntry.hash = ManifestGenerator.getHashFromMedia(resourceSubPath);
       } else {
-        let resourceLastModified;
         try {
-          resourceLastModified = await this.getLastModified(host, resourceSubPath);
+          resourceEntry.timestamp = await this.getLastModified(resourceEntry.path);
+          lastModified = Math.max(lastModified, resourceEntry.timestamp);
         } catch (e) {
-          // if resource if not available in codebus, validate if resource is locally available
-          if (!(await GitUtils.isFileDirty(resourceSubPath.slice(1)))) {
-            console.log(`resource ${resourceSubPath} not available for channel ${path}`);
-            // eslint-disable-next-line no-continue
-            continue;
-          }
+          console.log(`resource ${resourceEntry.path} not available for channel ${channelPath}`);
+          // skip this resource - do not add it as a manifest entry
+          return;
         }
-        lastModified = Math.max(lastModified, resourceLastModified);
-        resourceEntry.timestamp = resourceLastModified;
       }
       entriesJson.push(resourceEntry);
-    }
+    }));
 
     return [entriesJson, lastModified];
   };
 
-  static createManifest = async (host, manifestMap, path, isHtmlUpdatedMap, additionalAssets = []) => {
-    const data = manifestMap.get(path);
-    /* eslint-disable object-curly-newline */
-    const {
+  /**
+   *
+   * @param {string} channelPath - The path of the channel
+   * @param {[string]} additionalAssets - Additional resources added by generator
+   * @returns Manifest for the channel
+   */
+  createManifestForChannel = async (channelPath, additionalAssets = []) => {
+    // unwrap indexed manifest
+    let {
       scripts = '[]', styles = '[]', assets = '[]',
       inlineImages = '[]', dependencies = '[]', fragments = '[]'
-    } = data;
-    const scriptsList = JSON.parse(scripts);
-    const stylesList = JSON.parse(styles);
-    const assetsList = JSON.parse(assets);
-    assetsList.forEach(ManifestGenerator.trimImagesPath);
-    const inlineImagesList = JSON.parse(inlineImages);
-    inlineImagesList.forEach(ManifestGenerator.trimImagesPath);
-    const dependenciesList = JSON.parse(dependencies);
-    const pageResources = new Set([...scriptsList,
-      ...stylesList, ...assetsList,
-      ...inlineImagesList, ...dependenciesList, ...additionalAssets]);
+    } = this.indexedManifestsMap.get(channelPath);
 
-    const [entries, lastModified] = await ManifestGenerator
-      .createEntries(host, data.path, pageResources, isHtmlUpdatedMap.get(data.path));
+    scripts = JSON.parse(scripts);
+    styles = JSON.parse(styles);
+    assets = JSON.parse(assets);
+    inlineImages = JSON.parse(inlineImages);
+    dependencies = JSON.parse(dependencies);
+    fragments = JSON.parse(fragments);
+    assets.forEach(trimImagesPath);
+    inlineImages.forEach(trimImagesPath);
+
+    const pageResources = new Set([...scripts,
+      ...styles, ...assets,
+      ...inlineImages, ...dependencies, ...additionalAssets]);
+
     const allEntries = new Map();
-    entries.forEach((entry) => {
-      allEntries.set(entry.path, entry);
-    });
-    // add entries for all fragments
-    const fragmentsList = JSON.parse(fragments);
-    let fragmentsLastModified = 0;
-    // eslint-disable-next-line no-restricted-syntax
-    for (const fragmentPath of fragmentsList) {
-      // eslint-disable-next-line no-unused-vars
-      const [{ entries: newEntries }, fragmentLastModified] = await ManifestGenerator
-        .createManifest(host, manifestMap, fragmentPath, isHtmlUpdatedMap, [`${fragmentPath}.plain.html`]);
+    let [entries, lastModified] = await this.createManifestEntriesForChannel(channelPath, pageResources);
+    entries.forEach((entry) => allEntries.set(entry.path, entry));
 
-      fragmentsLastModified = Math.max(fragmentsLastModified, fragmentLastModified);
-      newEntries.forEach((entry) => {
+    // add entries for all fragments
+    await Promise.all(fragments.map(async (fragmentPath) => {
+      const fragmentManifest = await this.createManifestForChannel(fragmentPath, [`${fragmentPath}.plain.html`]);
+
+      lastModified = Math.max(lastModified, fragmentManifest.timestamp);
+      fragmentManifest.entries.forEach((entry) => {
         // rebase media URLs to current path
-        if (ManifestGenerator.isMedia(entry.path)) {
-          entry.path = ManifestGenerator.extractMediaFromPath(entry.path);
-          entry.path = PathUtils.getParentFromPath(path).concat(entry.path);
+        if (PathUtils.isMedia(entry.path)) {
+          entry.path = PathUtils.extractMediaFromPath(entry.path);
+          entry.path = PathUtils.getParentFromPath(channelPath).concat(entry.path);
         }
         allEntries.set(entry.path, entry);
       });
-    }
+    }));
 
-    // bug??
-    // const currentTime = new Date().getTime();
-    const manifestJson = {
+    // sort entries for consistent ordering
+    entries = Array.from(allEntries.values()).sort((a, b) => a.path.localeCompare(b.path));
+
+    return {
       version: '3.0',
-      timestamp: Math.max(lastModified, fragmentsLastModified),
-      entries: Array.from(allEntries.values()),
+      timestamp: lastModified,
+      entries,
       contentDelivery: {
         providers: [{ name: 'franklin', endpoint: '/' }],
         defaultProvider: 'franklin'
       }
     };
-    return [manifestJson, Math.max(lastModified, fragmentsLastModified)];
   };
 }

--- a/src/createManifest.js
+++ b/src/createManifest.js
@@ -133,6 +133,20 @@ export default class ManifestGenerator {
    * @returns Manifest for the channel
    */
   createManifestForChannel = async (channelPath, additionalAssets = []) => {
+    const manifest = {
+      version: '3.0',
+      timestamp: 0,
+      entries: [],
+      contentDelivery: {
+        providers: [{ name: 'franklin', endpoint: '/' }],
+        defaultProvider: 'franklin'
+      }
+    };
+
+    if (!this.indexedManifestsMap.has(channelPath)) {
+      return manifest;
+    }
+
     // unwrap indexed manifest
     let {
       scripts = '[]', styles = '[]', assets = '[]',
@@ -175,13 +189,9 @@ export default class ManifestGenerator {
     entries = Array.from(allEntries.values()).sort((a, b) => a.path.localeCompare(b.path));
 
     return {
-      version: '3.0',
+      ...manifest,
       timestamp: lastModified,
-      entries,
-      contentDelivery: {
-        providers: [{ name: 'franklin', endpoint: '/' }],
-        defaultProvider: 'franklin'
-      }
+      entries
     };
   };
 }

--- a/src/generateScreensOfflineResources.js
+++ b/src/generateScreensOfflineResources.js
@@ -162,6 +162,7 @@ export default class GenerateScreensOfflineResources {
    * Main method exposed to clients
    */
   static run = async (args) => {
+    const startTime = new Date();
     const parsedArgs = parseArgs(args);
     const indexedManifestPath = parsedArgs.helixManifest ? `${parsedArgs.helixManifest}.json` : '/manifest.json';
     const indexedChannelPath = parsedArgs.helixChannelsList ? `${parsedArgs.helixChannelsList}.json` : '/channels.json';
@@ -173,8 +174,7 @@ export default class GenerateScreensOfflineResources {
     resp = await FetchUtils.fetchDataWithMethod(host, indexedChannelPath, 'GET');
     const indexedChannels = await resp.json();
 
-    const startTime = new Date();
     await GenerateScreensOfflineResources.createOfflineResources(host, indexedManifests.data, indexedChannels.data);
-    console.log(`Manifest Generation took ${new Date() - startTime} time`);
+    console.log(`Offline Resource Generation took ${new Date() - startTime} ms`);
   };
 }

--- a/src/generateScreensOfflineResources.js
+++ b/src/generateScreensOfflineResources.js
@@ -1,5 +1,3 @@
-/* eslint-disable no-await-in-loop */
-/* eslint-disable max-len */
 /*
  * Copyright 2023 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
@@ -26,177 +24,157 @@ const logIfError = (err) => {
   }
 };
 
-async function importAndRun(fileName, ...args) {
-  let additionalAssets;
+const importAndRun = async (fileName, ...args) => {
   try {
     const module = await import(`${fileName}`);
     if (typeof module.default.generateHTML === 'function') {
-      additionalAssets = await module.default.generateHTML(...args);
-    } else {
-      console.log(`Function 'generateHTML' not found in module '${fileName}'. Fallback to default generator.`);
-      additionalAssets = await DefaultGenerator.generateHTML(...args);
+      return await module.default.generateHTML(...args);
     }
+    console.log(`Function 'generateHTML' not found in module '${fileName}'. Fallback to default generator.`);
+    return await DefaultGenerator.generateHTML(...args);
   } catch (error) {
     console.error(`Error importing module ${fileName}: ${error}. Fallback to default generator.`);
-    additionalAssets = DefaultGenerator.generateHTML(...args);
+    return DefaultGenerator.generateHTML(...args);
   }
-  return additionalAssets;
-}
+};
+
+const getHost = async () => {
+  const gitUrl = await GitUtils.getOriginURL(process.cwd(), {});
+  const gitBranch = await GitUtils.getBranch(process.cwd());
+  return `https://${gitBranch}--${gitUrl.repo}--${gitUrl.owner}.hlx.live`;
+};
+
+const parseArgs = (args) => {
+  const parsedArgs = {};
+  if (Array.isArray(args)) {
+    args.forEach((arg) => {
+      const parts = arg.split('=');
+      const [key, value] = parts;
+      parsedArgs[key] = value;
+    });
+  }
+  return parsedArgs;
+};
+
+const processLiveUrl = (liveUrl) => {
+  try {
+    const url = new URL(liveUrl);
+    url.pathname = `${url.pathname}.html`;
+    return url.toString();
+  } catch (err) {
+    /* eslint-disable no-console */
+    console.warn(`Invalid live url: ${liveUrl}`, err);
+  }
+  return liveUrl;
+};
+
+const createChannelMap = (channelsData) => channelsData.reduce((map, channel) => {
+  const channelPath = channel.path;
+  const channelData = {
+    ...channel,
+    liveUrl: processLiveUrl(channel.liveUrl)
+  };
+  map.set(channelPath, channelData);
+  return map;
+}, new Map());
+
+const createManifestMap = (manifestData) => manifestData.reduce((map, manifest) => {
+  map.set(manifest.path, manifest);
+  return map;
+}, new Map());
+
+const runGeneratorAndGetAdditionalAssets = async (host, channelPath) => {
+  const relativeChannelPath = channelPath.slice(1);
+  // fetch franklin page -> get generator -> generate page
+  const resp = await FetchUtils.fetchDataWithMethod(host, channelPath, 'GET');
+  const franklinMarkup = await resp.text();
+  const $ = load(franklinMarkup);
+  const template = $('meta[name="template"]').attr('content');
+  const templatePath = `${process.cwd()}/scripts/generators/${template}.js`;
+  if (template && await pathExists(templatePath)) {
+    return importAndRun(templatePath, host, relativeChannelPath);
+  }
+
+  return DefaultGenerator.generateHTML(host, relativeChannelPath);
+};
 
 export default class GenerateScreensOfflineResources {
-  static getHost = async () => {
-    const gitUrl = await GitUtils.getOriginURL(process.cwd(), {});
-    const gitBranch = await GitUtils.getBranch(process.cwd());
-    return `https://${gitBranch}--${gitUrl.repo}--${gitUrl.owner}.hlx.live`;
-  };
-
   /**
-   * Parse command line arguments
+   *
+   * @param {string} host - host for the franklin site
+   * @param {[Object]} indexedManifests - array of manifests indexed by franklin
+   * @param {[Object]} indexedChannels - array of channels indexed by franklin
    */
-  static parseArgs = (args) => {
-    const parsedArgs = {};
-    if (Array.isArray(args)) {
-      args.forEach((arg) => {
-        const parts = arg.split('=');
-        const [key, value] = parts;
-        parsedArgs[key] = value;
-      });
-    }
-    return parsedArgs;
-  };
+  static createOfflineResources = async (host, indexedManifests, indexedChannels) => {
+    const channelsMap = createChannelMap(indexedChannels);
+    const manifestMap = createManifestMap(indexedManifests);
 
-  static processLiveUrl = (liveUrl) => {
-    try {
-      const url = new URL(liveUrl);
-      url.pathname = `${url.pathname}.html`;
-      return url.toString();
-    } catch (err) {
-      /* eslint-disable no-console */
-      console.warn(`Invalid live url: ${liveUrl}`, err);
-    }
-    return liveUrl;
-  };
-
-  /**
-   * Create ChannelMap from the helix channels list
-   */
-  static createChannelMap = (channelsData) => {
-    const channelsMap = new Map();
-    for (let i = 0; i < channelsData.length; i++) {
-      const channelPath = channelsData[i].path;
-      const channelData = {};
-      channelData.externalId = channelsData[i].externalId;
-      channelData.liveUrl = GenerateScreensOfflineResources.processLiveUrl(channelsData[i].liveUrl);
-
-      channelData.editUrl = channelsData[i].editUrl;
-      channelData.title = channelsData[i].title;
-      channelsMap.set(channelPath, channelData);
-    }
-    return channelsMap;
-  };
-
-  /**
-   * Create offline resources
-   */
-  static createOfflineResources = async (
-    host,
-    manifests,
-    channelsList
-  ) => {
-    const totalManifests = parseInt(manifests.total, 10);
-    const manifestData = manifests.data;
-    const channelsData = channelsList.data;
-    const channelsMap = GenerateScreensOfflineResources.createChannelMap(channelsData);
     const channelJson = {
       channels: [],
       metadata: {
         providerType: 'franklin'
       }
     };
-
-    const manifestMap = manifestData.reduce((map, manifest) => {
-      map.set(manifest.path, manifest);
-      return map;
-    }, new Map());
-
     const additionalAssetsMap = new Map();
-    const isHtmlUpdatedMap = new Map();
 
-    for (let i = 0; i < totalManifests; i++) {
-      const data = manifestData[i];
-      const relativeChannelPath = data.path.slice(1);
+    let unfulfilledPromises = indexedManifests.map(async ({ path: channelPath }) => {
+      const additionalAssets = await runGeneratorAndGetAdditionalAssets(host, channelPath);
+      additionalAssetsMap.set(channelPath, additionalAssets);
+    });
+    await Promise.all(unfulfilledPromises);
 
-      // fetch franklin page -> get generator -> generate page
-      // eslint-disable-next-line no-await-in-loop
-      const resp = await FetchUtils.fetchDataWithMethod(host, data.path, 'GET');
-      const franklinMarkup = await resp.text();
-      const $ = load(franklinMarkup);
-      const template = $('meta[name="template"]').attr('content');
-      let additionalAssets;
-      if (template && await pathExists(`./scripts/generators/${template}.js`)) {
-        additionalAssets = await importAndRun(`${process.cwd()}/scripts/generators/${template}.js`, host, relativeChannelPath);
-      } else {
-        additionalAssets = await DefaultGenerator.generateHTML(host, relativeChannelPath);
-      }
+    const manifestGenerator = new ManifestGenerator(host, manifestMap);
 
-      let isHtmlUpdated = false;
-      if (await GitUtils.isFileDirty(`${relativeChannelPath}.html`)) {
-        console.log(`Git: Existing html at ${relativeChannelPath}.html is different from generated html.`);
-        isHtmlUpdated = true;
-      }
-      additionalAssetsMap.set(data.path, additionalAssets);
-      isHtmlUpdatedMap.set(data.path, isHtmlUpdated);
-    }
+    unfulfilledPromises = indexedManifests.map(async ({ path: channelPath }) => {
+      const additionalAssets = additionalAssetsMap.get(channelPath);
+      const manifest = await manifestGenerator.createManifestForChannel(channelPath, additionalAssets);
+      const manifestFilePath = `${channelPath.substring(1, channelPath.length)}.manifest.json`;
+      outputFile(manifestFilePath, JSON.stringify(manifest, null, 2), logIfError);
 
-    for (let i = 0; i < totalManifests; i++) {
-      const data = manifestData[i];
-      const [manifest, lastModified] = await ManifestGenerator.createManifest(host, manifestMap, data.path, isHtmlUpdatedMap, additionalAssetsMap.get(data.path));
-
-      const channelEntry = {
-        manifestPath: `${manifestData[i].path}.manifest.json`,
-        lastModified: new Date(lastModified)
+      const channelJsonEntry = {
+        manifestPath: `${channelPath}.manifest.json`,
+        lastModified: new Date(manifest.timestamp),
+        hierarchy: PathUtils.getParentHierarchy(channelPath)
       };
 
-      const hierarchy = PathUtils.getParentHierarchy(manifestData[i].path);
-      channelEntry.hierarchy = hierarchy;
-      if (channelsMap.get(manifestData[i].path)) {
-        channelEntry.externalId = channelsMap.get(manifestData[i].path).externalId
-          ? channelsMap.get(manifestData[i].path).externalId : '';
-        channelEntry.title = channelsMap.get(manifestData[i].path).title
-          ? channelsMap.get(manifestData[i].path).title : '';
-        channelEntry.liveUrl = channelsMap.get(manifestData[i].path).liveUrl
-          ? channelsMap.get(manifestData[i].path).liveUrl : '';
-        if (channelsMap.get(manifestData[i].path).editUrl) {
-          channelEntry.editUrl = channelsMap.get(manifestData[i].path).editUrl;
+      if (channelsMap.get(channelPath)) {
+        channelJsonEntry.externalId = channelsMap.get(channelPath).externalId || '';
+        channelJsonEntry.title = channelsMap.get(channelPath).title || '';
+        channelJsonEntry.liveUrl = channelsMap.get(channelPath).liveUrl || '';
+        if (channelsMap.get(channelPath).editUrl) {
+          channelJsonEntry.editUrl = channelsMap.get(channelPath).editUrl;
         }
       } else {
-        channelEntry.externalId = manifestData[i].path;
-        channelEntry.liveUrl = FetchUtils.createUrlFromHostAndPath(host, manifestData[i].path);
-        channelEntry.title = '';
+        channelJsonEntry.externalId = channelPath;
+        channelJsonEntry.liveUrl = FetchUtils.createUrlFromHostAndPath(host, channelPath);
+        channelJsonEntry.title = '';
       }
-      channelJson.channels.push(channelEntry);
-      let manifestFilePath = '';
-      manifestFilePath = `${manifestData[i].path.substring(1, manifestData[i].path.length)}.manifest.json`;
-      outputFile(manifestFilePath, JSON.stringify(manifest, null, 2), logIfError);
-    }
+      channelJson.channels.push(channelJsonEntry);
+    });
+    await Promise.all(unfulfilledPromises);
+
+    // sort entries for consistent ordering
+    channelJson.channels.sort((a, b) => a.externalId.localeCompare(b.externalId));
     outputFile('screens/channels.json', JSON.stringify(channelJson, null, 2), logIfError);
   };
 
+  /**
+   * Main method exposed to clients
+   */
   static run = async (args) => {
-    const parsedArgs = GenerateScreensOfflineResources.parseArgs(args);
-    const helixManifest = parsedArgs.helixManifest ? `${parsedArgs.helixManifest}.json` : '/manifest.json';
-    const helixChannelsList = parsedArgs.helixChannelsList
-      ? `${parsedArgs.helixChannelsList}.json` : '/channels.json';
+    const parsedArgs = parseArgs(args);
+    const indexedManifestPath = parsedArgs.helixManifest ? `${parsedArgs.helixManifest}.json` : '/manifest.json';
+    const indexedChannelPath = parsedArgs.helixChannelsList ? `${parsedArgs.helixChannelsList}.json` : '/channels.json';
+    const host = parsedArgs.customDomain || await getHost();
 
-    const host = parsedArgs.customDomain || await GenerateScreensOfflineResources.getHost();
-    let resp = await FetchUtils.fetchDataWithMethod(host, helixManifest, 'GET');
-    const manifests = await resp.json();
-    resp = await FetchUtils.fetchDataWithMethod(host, helixChannelsList, 'GET');
-    const channelsList = await resp.json();
-    await GenerateScreensOfflineResources.createOfflineResources(
-      host,
-      manifests,
-      channelsList
-    );
+    let resp = await FetchUtils.fetchDataWithMethod(host, indexedManifestPath, 'GET');
+    const indexedManifests = await resp.json();
+
+    resp = await FetchUtils.fetchDataWithMethod(host, indexedChannelPath, 'GET');
+    const indexedChannels = await resp.json();
+
+    const startTime = new Date();
+    await GenerateScreensOfflineResources.createOfflineResources(host, indexedManifests.data, indexedChannels.data);
+    console.log(`Manifest Generation took ${new Date() - startTime} time`);
   };
 }

--- a/src/utils/pathUtils.js
+++ b/src/utils/pathUtils.js
@@ -10,6 +10,8 @@
  * governing permissions and limitations under the License.
  */
 
+import Constants from '../constants.js';
+
 export default class PathUtils {
   static getParentFromPath = (path) => path.substring(0, path.lastIndexOf('/'));
 
@@ -27,5 +29,36 @@ export default class PathUtils {
     }
     hierarchy.reverse();
     return hierarchy;
+  };
+
+  /**
+   * Checks if the given resource path represents a media (image/video) hosted in Franklin.
+   *
+   * @param {string} resourcePath - The path of the resource to be checked.
+   * @returns {boolean} - True if the resource path represents a media hosted in Franklin, otherwise false.
+   */
+  static isMedia = (resourcePath) => resourcePath.trim().includes(Constants.MEDIA_PREFIX);
+
+  /**
+   * Returns the hash value of the media resource.
+   * For images hosted in Franklin, hash values are appended to the resource name.
+   *
+   * @param {string} resourcePath - The path of the media resource.
+   * @returns {string} - The hash value extracted from the media resource path.
+   */
+  static getHashFromMedia = (resourcePath) => {
+    const trimmedResourcePath = resourcePath.trim();
+    return trimmedResourcePath.substring(Constants.MEDIA_PREFIX.length, trimmedResourcePath.indexOf('.'));
+  };
+
+  /**
+   * Extracts the media path from the given resource path by removing the media prefix.
+   *
+   * @param {string} resourcePath - The path of the media resource.
+   * @returns {string} - The resource path after removing the media prefix.
+   */
+  static extractMediaFromPath = (resourcePath) => {
+    const trimmedResourcePath = resourcePath.trim();
+    return trimmedResourcePath.substring(trimmedResourcePath.indexOf(Constants.MEDIA_PREFIX));
   };
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

While running the offline resource generator for https://github.com/hlxscreens/cec-screens,  lastModified was incorrectly getting updated[0-1] for resources in the code bus.

This change use helix admin API to determine the sourceLastModified for resources in the code bus and use it instead of lastModified Header in the HEAD request for resource.

Also, I took this opportunity to refactor the code for better maintainability in the future.
While doing so, I recognised the areas which could be parallelised (like manifest creation of different channels).

On my local machine, it improved the speed around 3x for the same CEC project(although same speedup was not observed on the github action for reasons unknown).

[0] - https://github.com/hlxscreens/cec-screens/commit/a0247838441f39bccc7fcec9ba427c6b54f5543d
[1] - https://github.com/hlxscreens/cec-screens/commit/4520ab62381afc6a36d2b3314359cfbb322fd9ea

## How Has This Been Tested?
This change was tested for 2 weeks in the CEC project - https://github.com/hlxscreens/cec-screens/commit/df3f6d01d541a67ed83611203ff70de8dea16062

## Types of changes


- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
