### PR TITLE
hlx domain migration to aem

### DIFF
--- a/src/generateScreensOfflineResources.js
+++ b/src/generateScreensOfflineResources.js
@@ -41,7 +41,7 @@ const importAndRun = async (fileName, ...args) => {
 const getHost = async () => {
   const gitUrl = await GitUtils.getOriginURL(process.cwd(), {});
   const gitBranch = await GitUtils.getBranch(process.cwd());
-  return `https://${gitBranch}--${gitUrl.repo}--${gitUrl.owner}.hlx.live`;
+  return `https://${gitBranch}--${gitUrl.repo}--${gitUrl.owner}.aem.live`;
 };
 
 const parseArgs = (args) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

As per DOC, https://www.aem.live/developer/upgrade hlx. life will be deprecated, and we need to migrate to AEM. live domain

